### PR TITLE
fix: fixed first time login for Jenkins

### DIFF
--- a/values/common.yaml
+++ b/values/common.yaml
@@ -34,22 +34,24 @@ controller:
   overwritePlugins: true
   JCasC:
     defaultConfig: true
-    # This is not a typo, the plugin needed for this to work is "oic"
-    securityRealm: |-
-      oic:
-        clientId: "uds-core-jenkins"
-        clientSecret: "###ZARF_VAR_JENKINS_CLIENT_SECRET###"
-        wellKnownOpenIDConfigurationUrl: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds/.well-known/openid-configuration"
-        tokenServerUrl: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/token"
-        authorizationServerUrl: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/auth"
-        scopes: "openid profile"
-        disableSslVerification: false
-        endSessionEndpoint: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/logout"
-        escapeHatchEnabled: false
-        logoutFromOpenidProvider: true
-        userNameField: "preferred_username"
-        emailFieldName: "email"
-        groupsFieldName: "groups"
+    configScripts:
+      keycloak: |-
+        jenkins:
+          securityRealm:
+            oic:
+              clientId: "uds-core-jenkins"
+              clientSecret: "###ZARF_VAR_JENKINS_CLIENT_SECRET###"
+              wellKnownOpenIDConfigurationUrl: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds"
+              tokenServerUrl: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/token"
+              authorizationServerUrl: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/auth"
+              scopes: "openid profile"
+              disableSslVerification: false
+              endSessionEndpoint: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds/protocol/openid-connect/logout"
+              escapeHatchEnabled: false
+              logoutFromOpenidProvider: true
+              userNameField: "preferred_username"
+              emailFieldName: "email"
+              groupsFieldName: "groups"
   probes:
     startupProbe:
       periodSeconds: 10


### PR DESCRIPTION
When logging into Jenkins for the first time, would get invalid scopes for SSO