### PR TITLE
chore(docs): add back in lint.yaml

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+name: Lint
+
+on:
+  # This workflow is triggered on pull requests to the main branch.
+  pull_request:
+    branches: [main]
+    # milestoned is added here as a workaround for release-please not triggering PR workflows (PRs should be added to a milestone to trigger the workflow).
+    types: [milestoned, opened, edited, synchronize]
+
+jobs:
+  run:
+    uses: defenseunicorns/uds-common/.github/workflows/callable-lint.yaml@2a5e66fceb5c506008d5f69f42abcf38ccf86b44 # v1.2.0
+    secrets: inherit


### PR DESCRIPTION
add back in lint.yaml GitHub workflow
Accidentally removed it thinking it was under the tasks folder (which isn't necessary anymore)