### PR TITLE
fix: adds playwright image check for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,12 @@
       ]
     },
     {
+      "matchPackageNames": ["mcr.microsoft.com/playwright"],
+      "groupName": "jenkins Support Dependencies",
+      "labels": ["support-deps"],
+      "commitMessageTopic": "support-deps"
+    },
+    {
       "groupName": "jenkins Package Dependencies",
       "labels": [
         "package-deps"
@@ -59,6 +65,17 @@
       "versioningTemplate": "maven",
       "depNameTemplate": "jenkinsci/{{{depName}}}-plugin",
       "datasourceTemplate": "github-tags"
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^tasks/test.yaml$"],
+      "matchStrings": [
+        "mcr\\.microsoft\\.com/playwright:(?<currentValue>[^\\s\"']+)"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "mcr.microsoft.com/playwright",
+      "versioningTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
## Description

Adds a piece to the `renovate.json` to look for the playwright image used for testing
## Related Issue
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/uds-packages/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
